### PR TITLE
Added AWS 2.1.5 Proguard File

### DIFF
--- a/libraries/proguard-aws-2.1.5.pro
+++ b/libraries/proguard-aws-2.1.5.pro
@@ -1,0 +1,33 @@
+# These options are the minimal options for a functioning application
+# using Proguard and the AWS SDK 2.1.5 for Android
+
+-keep class org.apache.commons.logging.**               { *; }
+-keep class com.amazonaws.org.apache.commons.logging.** { *; }
+-keep class com.amazonaws.services.sqs.QueueUrlHandler  { *; }
+-keep class com.amazonaws.javax.xml.transform.sax.*     { public *; }
+-keep class com.amazonaws.javax.xml.stream.**           { *; }
+-keep class com.amazonaws.services.**.model.*Exception* { *; }
+-keep class com.amazonaws.internal.**                   { *; }
+-keep class org.codehaus.**                             { *; }
+-keep class org.joda.time.tz.Provider                   { *; }
+-keep class org.joda.time.tz.NameProvider               { *; }
+-keepattributes Signature,*Annotation*,EnclosingMethod
+-keepnames class com.fasterxml.jackson.** { *; }
+-keepnames class com.amazonaws.** { *; }
+
+-dontwarn com.fasterxml.jackson.databind.**
+-dontwarn javax.xml.stream.events.**
+-dontwarn org.codehaus.jackson.**
+-dontwarn org.apache.commons.logging.impl.**
+-dontwarn org.apache.http.conn.scheme.**
+-dontwarn org.apache.http.annotation.**
+-dontwarn org.ietf.jgss.**
+-dontwarn org.joda.convert.**
+-dontwarn com.amazonaws.org.joda.convert.**
+-dontwarn org.w3c.dom.bootstrap.**
+
+#SDK split into multiple jars so certain classes may be referenced but not used
+-dontwarn com.amazonaws.services.s3.**
+-dontwarn com.amazonaws.services.sqs.**
+
+-dontnote com.amazonaws.services.sqs.QueueUrlHandler


### PR DESCRIPTION
Here is the required proguard file for AWS for Android 2.1.5.  Amazon changed package names and moved a ton of stuff around without updating their examples.
