### PR TITLE
Remove strange strings.

### DIFF
--- a/libraries/proguard-flurry.pro
+++ b/libraries/proguard-flurry.pro
@@ -1,8 +1,8 @@
 ## Flurry 3.4.0 specific rules ##
 
-­-keep class com.flurry.** { *; }
-­-dontwarn com.flurry.**
-­-keepattributes *Annotation*,EnclosingMethod ­
+-keep class com.flurry.** { *; }
+-dontwarn com.flurry.**
+-keepattributes *Annotation*,EnclosingMethod
 -keepclasseswithmembers class * {
 	public <init>(android.content.Context, android.util.AttributeSet, int); 
 }


### PR DESCRIPTION
After pull whole project, the flurry proguard file contains some strange strings. Just remove them to make it work.