### PR TITLE
Added rule to protect CardView shadows from proguard

### DIFF
--- a/libraries/proguard-support-v7-cardview
+++ b/libraries/proguard-support-v7-cardview
@@ -1,0 +1,2 @@
+# http://stackoverflow.com/questions/29679177/cardview-shadow-not-appearing-in-lollipop-after-obfuscate-with-proguard/29698051
+-keep class android.support.v7.widget.RoundRectDrawable { *; }


### PR DESCRIPTION
I have faced this problem some hours ago, check [this link](http://stackoverflow.com/questions/29679177/cardview-shadow-not-appearing-in-lollipop-after-obfuscate-with-proguard/29698051) please

Thanks!