### PR TITLE
Don't warn for missing support classes in EventBus

### DIFF
--- a/libraries/proguard-eventbus.pro
+++ b/libraries/proguard-eventbus.pro
@@ -10,3 +10,6 @@
     public <init>(java.lang.Throwable);
 }
 
+# Don't warn for missing support classes
+-dontwarn de.greenrobot.event.util.*$Support
+-dontwarn de.greenrobot.event.util.*$SupportManagerFragment


### PR DESCRIPTION
When building without support library (target 14+), proguard is complaining about missing classes. This PR adds ignore clauses to skip the check.