### PR TITLE
Added --dontwarn sun.misc.Unsafe as per Guava documentation (Guava 18.0)

### DIFF
--- a/libraries/proguard-guava.pro
+++ b/libraries/proguard-guava.pro
@@ -23,3 +23,5 @@
 
 -keep class com.google.common.collect.MapMakerInternalMap$ReferenceEntry
 -keep class com.google.common.cache.LocalCache$ReferenceEntry
+
+-dontwarn sun.misc.Unsafe


### PR DESCRIPTION
It would not compile without this line for jsr305-3.0.0.jar (from http://mvnrepository.com/artifact/com.google.code.findbugs/jsr305).