### PR TITLE
Fix for ButterKnife 7.0

### DIFF
--- a/libraries/proguard-butterknife.pro
+++ b/libraries/proguard-butterknife.pro
@@ -1,6 +1,6 @@
 -keep class butterknife.** { *; }
 -dontwarn butterknife.internal.**
--keep class **$$ViewInjector { *; }
+-keep class **$$ViewBinder { *; }
 -keepclasseswithmembernames class * {
     @butterknife.* <fields>;
 }


### PR DESCRIPTION
ButterKnife 7.0 [comes](https://github.com/JakeWharton/butterknife/blob/master/CHANGELOG.md#version-700-2015-06-27) with some changes in syntax such as `@Bind` replaces `@InjectView` and this PR reflects accordingly. It's [mentioned](http://jakewharton.github.io/butterknife/#proguard) on the website too.