### PR TITLE
Match any type

### DIFF
--- a/libraries/proguard-eventbus.pro
+++ b/libraries/proguard-eventbus.pro
@@ -2,7 +2,7 @@
 # https://github.com/greenrobot/EventBus/blob/master/HOWTO.md#proguard-configuration
 
 -keepclassmembers class ** {
-    public void onEvent*(**);
+    public void onEvent*(***);
 }
 
 # Only required if you use AsyncExecutor


### PR DESCRIPTION
fixes issue 136. see: https://github.com/greenrobot/EventBus/issues/136

Problem: 
Current HOWTO.md suggests a Proguard line as such:

-keepclassmembers class ** {
    public void onEvent*(**);
}
If an registered object has for example 2 methods like:

public void onEvent(Client client){}
public void onEvent(Client[] clients){}
the second method gets removed by proguard because the ** does not match primitive arrays.

A *** in the parameter match of the proguard config will match the Client[] type and keep the method around after proguard has run.

Ref: http://proguard.sourceforge.net/manual/usage.html