### PR TITLE
Butterknife config is updated.

### DIFF
--- a/libraries/proguard-butterknife.pro
+++ b/libraries/proguard-butterknife.pro
@@ -1,6 +1,11 @@
+# Butterknife 7.x spesific rules #
+# https://github.com/JakeWharton/butterknife/ #
+
 -keep class butterknife.** { *; }
 -dontwarn butterknife.internal.**
 -keep class **$$ViewInjector { *; }
+-keep class **$$ViewBinder { *; }
+
 -keepclasseswithmembernames class * {
     @butterknife.* <fields>;
 }


### PR DESCRIPTION
- Butterknife config for version above 7.x is updated. I've kept the old `$$ViewInjector` line for the people using the old version of the library. Extra 1 line won't hurt. This way it will cover both versions. 
- Added a header.