### PR TITLE
Remove leakcanary proguard rule

### DIFF
--- a/libraries/proguard-leakcanary-1.3.1.pro
+++ b/libraries/proguard-leakcanary-1.3.1.pro
@@ -1,2 +1,0 @@
--keep class org.eclipse.mat.** { *; }
--keep class com.squareup.leakcanary.** { *; }


### PR DESCRIPTION
[Leak Canary bundles their proguard rules inside their AAR](https://github.com/square/leakcanary/blob/master/leakcanary-android/consumer-proguard-rules.pro) - no need to have people copy-pasting useless files into their scripts.