### PR TITLE
Update proguard-square-retrofit.pro

### DIFF
--- a/libraries/proguard-square-retrofit.pro
+++ b/libraries/proguard-square-retrofit.pro
@@ -1,11 +1,23 @@
--keep class com.squareup.okhttp.** { *; }
--keep interface com.squareup.okhttp.** { *; }
--dontwarn com.squareup.okhttp.**
+# Retrofit 1.X
 
--dontwarn rx.**
--dontwarn retrofit.**
--dontwarn okio.**
+-keep class com.squareup.okhttp.** { *; }
 -keep class retrofit.** { *; }
+-keep interface com.squareup.okhttp.** { *; }
+
+-dontwarn com.squareup.okhttp.**
+-dontwarn okio.**
+-dontwarn retrofit.**
+-dontwarn rx.**
+
 -keepclasseswithmembers class * {
     @retrofit.http.* <methods>;
 }
+
+# If in your rest service interface you use methods with Callback argument.
+-keepattributes Exceptions
+
+# If your rest service methods throw custom exceptions, because you've defined an ErrorHandler.
+-keepattributes Signature
+
+# Also you must note that if you are using GSON for conversion from JSON to POJO representation, you must ignore those POJO classes from being obfuscated.
+# Here include the POJO's that have you have created for mapping JSON response to POJO for example.


### PR DESCRIPTION
The proguard file for retrofit is incomplete. It does not support rest service interfaces with callbacks and error handling. This PR adds support for that.