### PR TITLE
ProGuard tip for android libraries developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ android {
 * [Square Wire](https://github.com/square/wire)
 * [Icepick](https://github.com/frankiesardo/icepick)
 * [Simple-Xml] (http://simple.sourceforge.net/)
+
+### ProGuard tip for android libraries developers
+The android libraries developers can include the proguard directives in the libraries. The Android Plugin for Gradle automatically appends ProGuard configuration files in an AAR (Android ARchive) package and appends that package to your ProGuard configuration
+
+The developers only need to specify the Proguard file with `consumerProguardFiles` instead of `proguardFiles`:
+
+```
+defaultConfig {
+    consumerProguardFiles 'proguard-file.txt'
+}
+```
+


### PR DESCRIPTION
A lot of android libraries (*.aar) don't include their proguard directives and the developers need to search for those configurations on the web and in some cases the information is outdated or incorrect. 
The Android Plugin for Gradle automatically appends the ProGuard configuration files in an AAR (Android ARchive) package and appends that package to the application ProGuard configuration, looks like most of the developers don't know this. This pull request adds this information to the README.md of this project.