### PR TITLE
Update Guava.

### DIFF
--- a/libraries/proguard-guava.pro
+++ b/libraries/proguard-guava.pro
@@ -1,10 +1,6 @@
-# Configuration for Guava
+# Configuration for Guava 18.0
 #
 # disagrees with instructions provided by Guava project: https://code.google.com/p/guava-libraries/wiki/UsingProGuardWithGuava
-#
-# works if you add the following line to the Gradle dependencies
-#
-# provided 'javax.annotation:jsr250-api:1.0'
 
 -keep class com.google.common.io.Resources {
     public static <methods>;
@@ -24,4 +20,7 @@
 -keep class com.google.common.collect.MapMakerInternalMap$ReferenceEntry
 -keep class com.google.common.cache.LocalCache$ReferenceEntry
 
+//http://stackoverflow.com/questions/9120338/proguard-configuration-for-guava-with-obfuscation-and-optimization
+-dontwarn javax.annotation.**
+-dontwarn javax.inject.**
 -dontwarn sun.misc.Unsafe


### PR DESCRIPTION
Update the Guava proguard rules to work with 18.+.  There are two ways to do this:  

A) Update the added dependency to jsr305.jar
B) Ignore the javax warnings.  

I decided to go with B) because the rules will work out of the box without an added dependency, and it seems safe to ignore the warnings.  However, there may be some consequences that I'm overlooking.  

More details on [Stack Overflow](http://stackoverflow.com/a/20935044/2364687).