### PR TITLE
fix line comment typo in proguard-guava.pro

### DIFF
--- a/libraries/proguard-guava.pro
+++ b/libraries/proguard-guava.pro
@@ -20,7 +20,7 @@
 -keep class com.google.common.collect.MapMakerInternalMap$ReferenceEntry
 -keep class com.google.common.cache.LocalCache$ReferenceEntry
 
-//http://stackoverflow.com/questions/9120338/proguard-configuration-for-guava-with-obfuscation-and-optimization
+# http://stackoverflow.com/questions/9120338/proguard-configuration-for-guava-with-obfuscation-and-optimization
 -dontwarn javax.annotation.**
 -dontwarn javax.inject.**
 -dontwarn sun.misc.Unsafe


### PR DESCRIPTION
Proguard uses only # for comments.