### PR TITLE
Don't warn about the simpleframework stream package

### DIFF
--- a/libraries/proguard-simple-xml.pro
+++ b/libraries/proguard-simple-xml.pro
@@ -4,6 +4,7 @@
 
 # Keep public classes and methods.
 -dontwarn com.bea.xml.stream.**
+-dontwarn org.simpleframework.xml.stream.**
 -keep class org.simpleframework.xml.**{ *; }
 -keepclassmembers,allowobfuscation class * {
     @org.simpleframework.xml.* <fields>;


### PR DESCRIPTION
I also get warnings from this additional package which prevents me to successfully build with abortOnError and warningsAsErrors.