### PR TITLE
Adds Retrofit2 ProGuard rules

### DIFF
--- a/libraries/proguard-square-retrofit2.pro
+++ b/libraries/proguard-square-retrofit2.pro
@@ -1,0 +1,6 @@
+# Retrofit 2.X
+
+-dontwarn retrofit2.**
+-keep class retrofit2.** { *; }
+-keepattributes Signature
+-keepattributes Exceptions

--- a/libraries/proguard-square-retrofit2.pro
+++ b/libraries/proguard-square-retrofit2.pro
@@ -1,4 +1,5 @@
 # Retrofit 2.X
+## https://square.github.io/retrofit/ ##
 
 -dontwarn retrofit2.**
 -keep class retrofit2.** { *; }


### PR DESCRIPTION
As per https://square.github.io/retrofit/

Note that it is intended that these don't replace those for Retrofit 1.x as both should be able to coexist within the same project (https://github.com/square/retrofit/releases/tag/parent-2.0.0-beta3).