### PR TITLE
Add ProGuard rules for RxJava 1.1.0

### DIFF
--- a/libraries/proguard-rx-java.pro
+++ b/libraries/proguard-rx-java.pro
@@ -12,3 +12,17 @@
 -keep class rx.schedulers.Schedulers {
     public static ** test();
 }
+
+# RxJava 1.1.0
+# See https://github.com/artem-zinnatullin/RxJavaProGuardRules
+
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+   long producerIndex;
+   long consumerIndex;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode producerNode;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode consumerNode;
+}


### PR DESCRIPTION
See https://github.com/artem-zinnatullin/RxJavaProGuardRules for updated RxJava rules.