### PR TITLE
rxjava: update for version 1.1.1

### DIFF
--- a/libraries/proguard-rx-java.pro
+++ b/libraries/proguard-rx-java.pro
@@ -1,4 +1,19 @@
-# RxJava 0.21
+# RxJava 1.1.1
+
+-dontwarn sun.misc.**
+
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+   long producerIndex;
+   long consumerIndex;
+}
+
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode producerNode;
+}
+
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode consumerNode;
+}
 
 -keep class rx.schedulers.Schedulers {
     public static <methods>;


### PR DESCRIPTION
After upgrading rxjava to 1.1.1, the original proguard rules did not work anymore. This resulted in runtime exceptions including `java.lang.NoSuchFieldException: producerIndex` ([more info](https://github.com/ReactiveX/RxJava/issues/3097)).

I now used the proguard rules from the [RxJavaProGuardRules](https://github.com/artem-zinnatullin/RxJavaProGuardRules/blob/master/rxjava-proguard-rules/proguard-rules.txt) project.
I'm unsure whether the original rules are still actually needed, so I left them as-is.
