### PR TITLE
annotations should be kept

### DIFF
--- a/libraries/proguard-jackson-2.pro
+++ b/libraries/proguard-jackson-2.pro
@@ -1,5 +1,15 @@
 # Proguard configuration for Jackson 2.x (fasterxml package instead of codehaus package)
 
+-keepnames class com.fasterxml.jackson.annotation.** { *; }
+-keep public class your.package.with.jackson.pojos.* {
+    public void set*(*);
+    public ** get*();
+}
+-dontwarn org.w3c.dom.bootstrap.DOMImplementationRegistry
+-dontwarn java.beans.Transient
+-dontwarn java.beans.ConstructorProperties
+
+# Not sure if those are needed in other configurations
 -keep class com.fasterxml.jackson.databind.ObjectMapper {
     public <methods>;
     protected <methods>;


### PR DESCRIPTION
issues like #19 is fixed by keeping all name from the annotations package (could sure be optimized but I'm not that deep into this stuff)
for custom pojos one has to keep the public setters and getters.
I kept the original proguard config since I do not know if it's needed in any other case. (in my  project using custom pojos they were not necessary)

The `-dontwarn` lines were needed since proguard kept complaining about those and my builds therefore failed.
