### PR TITLE
Update proguard-rx-java.pro

### DIFF
--- a/libraries/proguard-rx-java.pro
+++ b/libraries/proguard-rx-java.pro
@@ -1,5 +1,16 @@
-# RxJava 0.21
+# RxJava 1.1.2
 
+-dontwarn sun.misc.**
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+   long producerIndex;
+   long consumerIndex;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode producerNode;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode consumerNode;
+}
 -keep class rx.schedulers.Schedulers {
     public static <methods>;
 }


### PR DESCRIPTION
RxJava rules for version 1.1.2
