### PR TITLE
Add rules for log4j

### DIFF
--- a/libraries/proguard-log4j.pro
+++ b/libraries/proguard-log4j.pro
@@ -1,0 +1,7 @@
+# Log4j
+-dontwarn org.apache.log4j.**
+-dontnote org.apache.log4j.**
+
+-dontwarn java.beans.PropertyDescriptor
+-dontnote java.beans.PropertyDescriptor
+


### PR DESCRIPTION
Add rules for `Apache Log4j` logging library
https://logging.apache.org/log4j/

---

gradle dependencies is listed below

```
dependencies {
    compile 'de.mindpipe.android:android-logging-log4j:1.0.3'
    compile 'log4j:log4j:1.2.17'
}
```
