### PR TITLE
Update proguard file name to the default name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The developers only need to specify the Proguard file with `consumerProguardFile
 
 ```
 defaultConfig {
-    consumerProguardFiles 'proguard-file.pro'
+    consumerProguardFiles 'proguard-rules.pro'
+
 }
 ```


### PR DESCRIPTION
Changed the name of the proguard file to reflect the name that Android Studio creates by default.