### PR TITLE
Update OkHttp rules to follow official docs

### DIFF
--- a/libraries/proguard-square-okhttp3.pro
+++ b/libraries/proguard-square-okhttp3.pro
@@ -1,6 +1,2 @@
 # OkHttp
--keepattributes Signature
--keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
 -dontwarn okhttp3.**


### PR DESCRIPTION
Here are the official docs. 
https://github.com/square/okhttp#proguard

And according to this issue https://github.com/square/okhttp/issues/2230
These rules listed in the repo are aggressive.