### PR TITLE
Remove outdated ProGuard rules

### DIFF
--- a/libraries/proguard-square-okio.pro
+++ b/libraries/proguard-square-okio.pro
@@ -1,5 +1,2 @@
 # Okio
--keep class sun.misc.Unsafe { *; }
--dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn okio.**


### PR DESCRIPTION
These classes are in O now. And everyone should compile against O (even if they don't target it).