### PR TITLE
Fix proguard-guava.pro for issue #89

### DIFF
--- a/libraries/proguard-guava.pro
+++ b/libraries/proguard-guava.pro
@@ -16,9 +16,13 @@
     public static com.google.common.base.Joiner on(java.lang.String);
     public ** join(...);
 }
+-keepclassmembers class ** {
+    @com.google.common.eventbus.Subscribe public *;
+}
 
 -keep class com.google.common.collect.MapMakerInternalMap$ReferenceEntry
 -keep class com.google.common.cache.LocalCache$ReferenceEntry
+
 
 # http://stackoverflow.com/questions/9120338/proguard-configuration-for-guava-with-obfuscation-and-optimization
 -dontwarn javax.annotation.**


### PR DESCRIPTION
 Guava configuration ProGuard removes annotated EventBus subscriber methods and so events are fired but not consumed.