### PR TITLE
Update proguard-logback-android.pro

### DIFF
--- a/libraries/proguard-logback-android.pro
+++ b/libraries/proguard-logback-android.pro
@@ -2,13 +2,14 @@
 #
 # Tested on the following *.gradle dependencies
 #
-#    compile 'org.slf4j:slf4j-api:1.7.7'
-#    compile 'com.github.tony19:logback-android-core:1.1.1-3'
-#    compile 'com.github.tony19:logback-android-classic:1.1.1-3'
+#    compile 'org.slf4j:slf4j-api:1.7.25'
+#    compile 'com.github.tony19:logback-android-core:2.0.0'
 #
 
 -keep class ch.qos.** { *; }
 -keep class org.slf4j.** { *; }
 -keepattributes *Annotation*
 -dontwarn ch.qos.logback.core.net.*
-
+-dontwarn javax.mail.**
+-dontwarn javax.naming.Context
+-dontwarn javax.naming.InitialContext


### PR DESCRIPTION
- Updating rules for version 2.0.0 of loggback-android.
- Adding additional 'dontwarn' on javax.mail preventing build.
- Removing also  com.github.tony19:logback-android-classic ( deprecated? )